### PR TITLE
Several small fixes and an example configure command for OS X.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -76,11 +76,6 @@ dnl | C++ support
 dnl +-------------------------
 AC_PROG_CXX
 
-dnl +------------------------------------------------
-dnl | Check for C++11 language support
-dnl +------------------------------------------------
-AX_CXX_COMPILE_STDCXX([11], [noext], [mandatory])
-
 dnl +-------------------------
 dnl | Fortran support
 dnl +-------------------------
@@ -103,6 +98,9 @@ dnl +------------------------------------------------
 dnl | This is a C++ project...
 dnl +------------------------------------------------
 AC_LANG([C++])
+
+dnl Ensure that pkg-config is setup
+PKG_PROG_PKG_CONFIG
 
 dnl +------------------------------------------------
 dnl | Check for MPI
@@ -133,6 +131,17 @@ if test $tidas_mpi = yes; then
 fi
 AM_CONDITIONAL([HAVE_AM_MPI], [test $tidas_mpi = yes])
 AM_CONDITIONAL([HAVE_AM_MPI_FC], [test $tidas_mpi_fortran = yes])
+
+dnl +------------------------------------------------
+dnl | Check for C++11 language support
+dnl | since this modifies CXX and MPICXX, save these
+dnl | in other variables for later use.
+dnl +------------------------------------------------
+CXX_ORIG="$CXX"
+MPICXX_ORIG="$MPICXX"
+AC_SUBST([CXX_ORIG])
+AC_SUBST([MPICXX_ORIG])
+AX_CXX_COMPILE_STDCXX([11], [noext], [mandatory])
 
 dnl +-------------------------
 dnl | Option to perform full static linking of executables, not just

--- a/fixlibtool/Makefile.am
+++ b/fixlibtool/Makefile.am
@@ -9,9 +9,11 @@ fixlibtool : $(top_srcdir)/libtool
 	@echo "Fixing libtool" \
     && cat $(top_srcdir)/libtool \
     | sed -e "s#CC=\"$(CC)\"#CC=\"$(MPICC)\"#g" \
-    | sed -e "s#CC=\"$(CXX)\"#CC=\"$(MPICXX)\"#g" \
+    | sed -e "s#CC=\"$(CXX_ORIG)\"#CC=\"$(MPICXX_ORIG)\"#g" \
     | sed -e "s#CC=\"$(FC)\"#CC=\"$(MPIFC)\"#g" \
     > $(top_srcdir)/libtool_mpi \
     && chmod +x $(top_srcdir)/libtool_mpi \
     && touch fixlibtool
+
+CLEANFILES = fixlibtool
 

--- a/m4/ax_cxx_compile_stdcxx.m4
+++ b/m4/ax_cxx_compile_stdcxx.m4
@@ -85,6 +85,9 @@ AC_DEFUN([AX_CXX_COMPILE_STDCXX], [dnl
         if test -n "$CXXCPP" ; then
           CXXCPP="$CXXCPP $switch"
         fi
+        if test -n "$MPICXX" ; then
+          MPICXX="$MPICXX $switch"
+        fi
         ac_success=yes
         break
       fi
@@ -110,6 +113,9 @@ AC_DEFUN([AX_CXX_COMPILE_STDCXX], [dnl
         CXX="$CXX $switch"
         if test -n "$CXXCPP" ; then
           CXXCPP="$CXXCPP $switch"
+        fi
+        if test -n "$MPICXX" ; then
+          MPICXX="$MPICXX $switch"
         fi
         ac_success=yes
         break

--- a/platforms/osx-clang-condaforge.sh
+++ b/platforms/osx-clang-condaforge.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+#
+# This config assumes use of clang and Anaconda python,
+# using mpich, mpi4py, HDF5 from the conda-forge channel.
+# 
+# 1.  Install miniconda / anaconda
+#
+# 2.  Edit ~/.condarc to look like this:
+#
+#     channels:
+#         - conda-forge
+#         - defaults
+#
+# 3.  Install numpy, mpich, mpi4py, hdf5
+#
+# 4.  In order to link against the relocatable shared
+#     libraries installed by conda packages (which have
+#     relative @rpaths), you must add the conda
+#     environment lib directory to $DYLD_LIBRARY_PATH.
+#     This is needed (for example) to use HDF5 and CFITSIO
+#     libraries installed by conda packages.
+#
+
+OPTS="$@"
+
+condabin=$(dirname $(which python))
+
+export CC=clang
+export CXX=clang++
+export MPICC=mpicc
+export MPICXX=mpicxx
+export CFLAGS="-O3 -g"
+export CXXFLAGS="-O3 -g"
+
+./configure ${OPTS} \
+--disable-fortran \
+--disable-getdata \
+--with-hdf5=${condabin}/h5cc
+

--- a/src/tidas/test.py
+++ b/src/tidas/test.py
@@ -383,9 +383,9 @@ def test_mpi_volume_setup(vol, nblock, nsamp):
 
 
 def test_mpi(tmpdir=None, recurse=False):
+    from mpi4py import MPI
     from .mpi_volume import MPIVolume
     from .ctidas_mpi import mpi_dist_uniform
-    from mpi4py import MPI
 
     comm = MPI.COMM_WORLD
 


### PR DESCRIPTION
This works for me on OS X with dependencies installed through conda.  All unit tests pass.  I also checked that unit tests pass on Linux with these changes.