### PR TITLE
Small but important fixes to python bindings

### DIFF
--- a/examples/demo_telescope.py
+++ b/examples/demo_telescope.py
@@ -140,7 +140,7 @@ for year in ["2018",]:
             weather = tidas.Group(weather_schema, tidas.Dictionary(),
                 weather_daysamples)
             weather = db.group_add("weather", weather)
-            weather.write_times(np.linspace(daystartsec,
+            weather.write_times(0, np.linspace(daystartsec,
                 daystartsec + day_seconds, num=weather_daysamples))
 
             data = np.absolute(np.random.normal(loc=0.0, scale=5.0,
@@ -171,7 +171,7 @@ for year in ["2018",]:
 
             hk = tidas.Group(hk_schema, tidas.Dictionary(), hk_daysamples)
             hk = db.group_add("hk", hk)
-            hk.write_times(np.linspace(daystartsec,
+            hk.write_times(0, np.linspace(daystartsec,
                 daystartsec + day_seconds, num=hk_daysamples))
 
             data = np.random.normal(loc=273.0, scale=5.0,
@@ -187,7 +187,7 @@ for year in ["2018",]:
             pointing = tidas.Group(pointing_schema, tidas.Dictionary(),
                 pointing_daysamples)
             pointing = db.group_add("pointing", pointing)
-            pointing.write_times(np.linspace(daystartsec,
+            pointing.write_times(0, np.linspace(daystartsec,
                 daystartsec + day_seconds, num=pointing_daysamples))
 
             data = 2.0 * np.pi * np.random.random(
@@ -207,7 +207,7 @@ for year in ["2018",]:
             det = tidas.Group(det_schema, tidas.Dictionary(),
                 det_daysamples)
             det = db.group_add("detectors", det)
-            det.write_times(np.linspace(daystartsec,
+            det.write_times(0, np.linspace(daystartsec,
                 daystartsec + day_seconds, num=det_daysamples))
 
             for d in range(ndet):

--- a/examples/demo_weather.py
+++ b/examples/demo_weather.py
@@ -110,13 +110,13 @@ for year in ["2018", "2019"]:
 
             # Write timestamps to all groups
 
-            wind.write_times(np.linspace(daystartsec,
+            wind.write_times(0, np.linspace(daystartsec,
                 daystartsec + day_seconds, num=wind_daysamples))
 
-            thermal.write_times(np.linspace(daystartsec,
+            thermal.write_times(0, np.linspace(daystartsec,
                 daystartsec + day_seconds, num=thermal_daysamples))
 
-            precip.write_times(np.linspace(daystartsec,
+            precip.write_times(0, np.linspace(daystartsec,
                 daystartsec + day_seconds, num=precip_daysamples))
 
             # Write some random data to the fields

--- a/examples/io_timing.py
+++ b/examples/io_timing.py
@@ -172,7 +172,7 @@ def group_setup(grp, ndet, nsamp):
         float64_data[i] = fi
         string_data[i] = 'foobarbahblat'
 
-    grp.write_times(time)
+    grp.write_times(0, time)
     grp.write("int8", 0, int8_data)
     grp.write("uint8", 0, uint8_data)
     grp.write("int16", 0, int16_data)
@@ -224,7 +224,7 @@ def group_verify(grp, ndet, nsamp):
         float64_data_check[i] = fi
         string_data_check[i] = 'foobarbahblat'
 
-    time = grp.read_times()
+    time = grp.read_times(0, nsamp)
     int8_data = grp.read("int8", 0, nsamp)
     uint8_data = grp.read("uint8", 0, nsamp)
     int16_data = grp.read("int16", 0, nsamp)

--- a/src/libtidas-mpi/include/tidas/mpi.hpp
+++ b/src/libtidas-mpi/include/tidas/mpi.hpp
@@ -204,8 +204,8 @@ namespace tidas {
 
         // Communicate
 
-        ret = MPI_Gatherv ( (void*)&sendbuf[0], size, MPI_CHAR, recvptr, counts, displs,
-            MPI_CHAR, root, comm );
+        ret = MPI_Gatherv ( (void*)&sendbuf[0], size, MPI_CHAR, recvptr,
+            counts, displs, MPI_CHAR, root, comm );
 
         // Clear the result vector and deserialize
 

--- a/src/libtidas-mpi/src/tidas_mpi_volume.cpp
+++ b/src/libtidas-mpi/src/tidas_mpi_volume.cpp
@@ -260,9 +260,9 @@ void tidas::mpi_volume::close ( ) {
 
     // for ( int p = 0; p < nproc_; ++p ) {
     //     if ( rank_ == p ) {
-    //         std::cout << "DBG: mpi_volume close proc " << p << " local:" << std::endl;
+    //         std::cerr << "DBG: mpi_volume close proc " << p << " local:" << std::endl;
     //         for ( auto const & h : hist ) {
-    //             h.print ( std::cout );
+    //             h.print ( std::cerr );
     //         }
     //     }
     //     int blah = MPI_Barrier ( comm_ );
@@ -276,9 +276,9 @@ void tidas::mpi_volume::close ( ) {
 
     if ( rank_ == 0 ) {
         for ( size_t i = 0; i < nproc_; ++i ) {
-            // std::cout << "DBG: mpi_volume close replaying from proc " << i << ":" << std::endl;
+            // std::cerr << "DBG: mpi_volume close replaying from proc " << i << ":" << std::endl;
             // for ( auto const & h : allhist[i] ) {
-            //     h.print ( std::cout );
+            //     h.print ( std::cerr );
             // }
 
             if ( loc_.path != "" ) {
@@ -351,9 +351,9 @@ void tidas::mpi_volume::copy ( MPI_Comm comm, mpi_volume const & other, string c
     // Check that we have no outstanding transactions in the source volume.
     size_t histsize = other.localdb_->history().size();
     if ( histsize > 0 ) {
-        for ( auto & it : other.localdb_->history() ) {
-            it.print(std::cerr);
-        }
+        // for ( auto & it : other.localdb_->history() ) {
+        //     it.print(std::cerr);
+        // }
         ostringstream o;
         o << "process " << rank_ << " in mpi_volume copy source has " << histsize << " outstanding transactions";
         TIDAS_THROW( o.str().c_str() );

--- a/src/libtidas/include/tidas/dict.hpp
+++ b/src/libtidas/include/tidas/dict.hpp
@@ -131,7 +131,7 @@ namespace tidas {
             /// Insert a value into the dictionary with the specified key.
             template < class T >
             void put ( std::string const & key, T const & val ) {
-                std::string sval = tidas::data_to_string < T > ( val );
+                std::string sval = tidas::data_to_string ( val );
                 data_[ key ] = sval;
                 types_[ key ] = data_type_get ( typeid ( val ) );
                 return;

--- a/src/libtidas/include/tidas/group.hpp
+++ b/src/libtidas/include/tidas/group.hpp
@@ -275,6 +275,9 @@ namespace tidas {
             /// The extrema values of the timestamp field.
             void range ( time_type & start, time_type & stop ) const;
 
+            /// Explicitly check timestamps and update group metadata.
+            void update_range ();
+
             /// Read a range of data from a field.  Store results to the bare
             /// memory address specified.
             template < class T >

--- a/src/libtidas/include/tidas/utils.hpp
+++ b/src/libtidas/include/tidas/utils.hpp
@@ -128,9 +128,9 @@ namespace tidas {
         double f64;
 
         if ( typeid ( ret ) == typeid ( int8 ) ) {
-            ret = static_cast < T > ( str[0] );
+            ret = static_cast < T > ( stol ( str ) );
         } else if ( typeid ( ret ) == typeid ( uint8 ) ) {
-            ret = static_cast < T > ( str[0] );
+            ret = static_cast < T > ( stoul ( str ) );
         } else if ( typeid ( ret ) == typeid ( int16 ) ) {
             ret = static_cast < T > ( stol ( str ) );
         } else if ( typeid ( ret ) == typeid ( uint16 ) ) {
@@ -156,16 +156,31 @@ namespace tidas {
     template <>
     std::string data_from_string < std::string > ( std::string const & str );
 
-    template < typename T >
-    std::string data_to_string ( T const & val ) {
-        std::ostringstream o;
-        o.precision(16);
-        o.str("");
-        if ( ! ( o << val ) ) {
-            TIDAS_THROW( "cannot convert data to string" );
-        }
-        return o.str();
-    }
+
+    // Here we explicitly provide overloads for each time, to avoid template
+    // resolution doing the wrong thing.
+
+    std::string data_to_string ( double const & val );
+
+    std::string data_to_string ( float const & val );
+
+    std::string data_to_string ( int64_t const & val );
+
+    std::string data_to_string ( uint64_t const & val );
+
+    std::string data_to_string ( int32_t const & val );
+
+    std::string data_to_string ( uint32_t const & val );
+
+    std::string data_to_string ( int16_t const & val );
+
+    std::string data_to_string ( uint16_t const & val );
+
+    std::string data_to_string ( std::string const & val );
+
+    std::string data_to_string ( int8_t const & val );
+
+    std::string data_to_string ( uint8_t const & val );
 
 
     // general regular expression filters

--- a/src/libtidas/src/tidas_intervals.cpp
+++ b/src/libtidas/src/tidas_intervals.cpp
@@ -294,9 +294,8 @@ interval_list tidas::intervals::read_data () const {
 
 void tidas::intervals::write_data ( interval_list const & intr ) {
     if ( ! backend_ ) {
-        TIDAS_THROW( "intervals read_data:  backend not assigned" );
+        TIDAS_THROW( "intervals write_data:  backend not assigned" );
     }
-
     backend_->write_data ( loc_, intr );
     return;
 }

--- a/src/libtidas/src/tidas_utils.cpp
+++ b/src/libtidas/src/tidas_utils.cpp
@@ -388,6 +388,103 @@ std::string tidas::data_from_string < std::string > ( std::string const & str ) 
 }
 
 
+std::string tidas::data_to_string ( double const & val ) {
+    std::ostringstream o;
+    o.precision(18);
+    o.str("");
+    if ( ! ( o << std::scientific << val ) ) {
+        TIDAS_THROW( "cannot convert double data to string" );
+    }
+    return o.str();
+}
+
+
+std::string tidas::data_to_string ( float const & val ) {
+    std::ostringstream o;
+    o.precision(8);
+    o.str("");
+    if ( ! ( o << std::scientific << val ) ) {
+        TIDAS_THROW( "cannot convert float data to string" );
+    }
+    return o.str();
+}
+
+
+std::string tidas::data_to_string ( int64_t const & val ) {
+    std::ostringstream o;
+    o.str("");
+    if ( ! ( o << val ) ) {
+        TIDAS_THROW( "cannot convert int64 data to string" );
+    }
+    return o.str();
+}
+
+
+std::string tidas::data_to_string ( uint64_t const & val ) {
+    std::ostringstream o;
+    o.str("");
+    if ( ! ( o << val ) ) {
+        TIDAS_THROW( "cannot convert uint64 data to string" );
+    }
+    return o.str();
+}
+
+
+std::string tidas::data_to_string ( int32_t const & val ) {
+    std::ostringstream o;
+    o.str("");
+    if ( ! ( o << val ) ) {
+        TIDAS_THROW( "cannot convert int32 data to string" );
+    }
+    return o.str();
+}
+
+
+std::string tidas::data_to_string ( uint32_t const & val ) {
+    std::ostringstream o;
+    o.str("");
+    if ( ! ( o << val ) ) {
+        TIDAS_THROW( "cannot convert uint32 data to string" );
+    }
+    return o.str();
+}
+
+
+std::string tidas::data_to_string ( int16_t const & val ) {
+    std::ostringstream o;
+    o.str("");
+    if ( ! ( o << val ) ) {
+        TIDAS_THROW( "cannot convert int16 data to string" );
+    }
+    return o.str();
+}
+
+
+std::string tidas::data_to_string ( uint16_t const & val ) {
+    std::ostringstream o;
+    o.str("");
+    if ( ! ( o << val ) ) {
+        TIDAS_THROW( "cannot convert uint16 data to string" );
+    }
+    return o.str();
+}
+
+
+std::string tidas::data_to_string ( std::string const & val ) {
+    return std::string ( val );
+}
+
+
+std::string tidas::data_to_string ( int8_t const & val ) {
+    return tidas::data_to_string ( static_cast < int16_t > ( val ) );
+}
+
+
+std::string tidas::data_to_string ( uint8_t const & val ) {
+    return tidas::data_to_string ( static_cast < uint16_t > ( val ) );
+}
+
+
 string tidas::filter_default ( string const & filter ) {
     string ret = filter;
     if ( ret == "" ) {

--- a/src/python/test.py
+++ b/src/python/test.py
@@ -28,8 +28,8 @@ from tidas import (DataType, BackendType, CompressionType, AccessMode,
 def test_dict_setup():
     ret = Dictionary()
     ret.put_string("string", "blahblahblah")
-    ret.put_float64("float64", -123456789.0123)
-    ret.put_float32("float32", -123.456)
+    ret.put_float64("float64", -1.234567890123e9)
+    ret.put_float32("float32", -1.234567)
     ret.put_int8("int8", -100)
     ret.put_uint8("uint8", 100)
     ret.put_int16("int16", -10000)
@@ -51,8 +51,8 @@ def test_dict_verify(dct):
     nt.assert_equal(dct.get_uint32("uint32"), 1000000000)
     nt.assert_equal(dct.get_int64("int64"), -100000000000)
     nt.assert_equal(dct.get_uint64("uint64"), 100000000000)
-    nt.assert_almost_equal(dct.get_float32("float32"), -123.456, decimal=3)
-    nt.assert_almost_equal(dct.get_float64("float64"), -123456789.0123)
+    nt.assert_almost_equal(dct.get_float32("float32"), -1.234567)
+    nt.assert_almost_equal(dct.get_float64("float64"), -1.234567890123e9)
     return
 
 
@@ -170,7 +170,7 @@ def test_group_setup(grp, nsamp):
         float64_data[i] = fi
         string_data[i] = 'foobarbahblat'
 
-    grp.write_times(time)
+    grp.write_times(0, time)
     grp.write("int8", 0, int8_data)
     grp.write("uint8", 0, uint8_data)
     grp.write("int16", 0, int16_data)
@@ -216,7 +216,7 @@ def test_group_verify(grp, nsamp):
         float64_data_check[i] = fi
         string_data_check[i] = 'foobarbahblat'
 
-    time = grp.read_times()
+    time = grp.read_times(0, nsamp)
     int8_data = grp.read("int8", 0, nsamp)
     uint8_data = grp.read("uint8", 0, nsamp)
     int16_data = grp.read("int16", 0, nsamp)

--- a/src/tests-mpi/tidas_mpi_test.hpp
+++ b/src/tests-mpi/tidas_mpi_test.hpp
@@ -15,8 +15,11 @@ namespace tidas { namespace test {
 
     int mpi_runner ( int argc, char *argv[] );
 
-    void mpi_volume_setup ( tidas::mpi_volume & vol, size_t n_samp, size_t n_intr,
-        size_t n_block );
+    void mpi_volume_setup ( tidas::mpi_volume & vol, size_t n_samp,
+        size_t n_intr, size_t n_block );
+
+    void mpi_volume_root_setup ( tidas::mpi_volume & vol, size_t n_samp,
+        size_t n_intr, size_t n_block );
 
     void mpi_volume_verify ( tidas::mpi_volume & vol );
 


### PR DESCRIPTION
Cleanups to some string conversions.  Add support for writing subsets of the timestamps in a group.  Fix return policy for some python bindings.  Update examples to use new API.