### PR TITLE
Clean up build systems to install a shared library.

### DIFF
--- a/src/libtidas-mpi/CMakeLists.txt
+++ b/src/libtidas-mpi/CMakeLists.txt
@@ -1,34 +1,61 @@
 
-# Add the library target
+# Name of the serial internal static library
+set(TIDAS_STATIC tidas_)
 
-add_library(tidas-mpi
+# Name of the serial loadable module / shared library
+set(TIDAS_SHARED tidas)
+
+# Name of the MPI internal static library
+set(TIDAS_MPI_STATIC tidas-mpi_)
+
+# Name of the MPI loadable module / shared library
+set(TIDAS_MPI_SHARED tidas-mpi)
+
+# MPI sources
+set(TIDAS_MPI_SOURCES
     src/tidas_mpi.cpp
     src/tidas_mpi_volume.cpp
 )
 
-target_include_directories(tidas-mpi PUBLIC
+# Add the library targets
+
+add_library(${TIDAS_MPI_STATIC} STATIC ${TIDAS_MPI_SOURCES})
+add_library(${TIDAS_MPI_SHARED} SHARED ${TIDAS_MPI_SOURCES})
+
+target_include_directories(${TIDAS_MPI_STATIC} PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
     $<INSTALL_INTERFACE:include>
     PRIVATE src)
 
-target_include_directories(tidas-mpi PRIVATE
+target_include_directories(${TIDAS_MPI_SHARED} PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include>
+    PRIVATE src)
+
+target_include_directories(${TIDAS_MPI_STATIC} PRIVATE
     "${CMAKE_CURRENT_SOURCE_DIR}"
     "${CMAKE_CURRENT_SOURCE_DIR}/../libtidas/src"
 )
 
-target_include_directories(tidas-mpi PRIVATE "${MPI_CXX_INCLUDE_PATH}")
+target_include_directories(${TIDAS_MPI_SHARED} PRIVATE
+    "${CMAKE_CURRENT_SOURCE_DIR}"
+    "${CMAKE_CURRENT_SOURCE_DIR}/../libtidas/src"
+)
+
+target_include_directories(${TIDAS_MPI_STATIC} PRIVATE "${MPI_CXX_INCLUDE_PATH}")
+target_include_directories(${TIDAS_MPI_SHARED} PRIVATE "${MPI_CXX_INCLUDE_PATH}")
 
 string(STRIP "${MPI_CXX_COMPILE_FLAGS}" mpi_comp_flags)
-target_compile_options(tidas-mpi PRIVATE "${mpi_comp_flags}")
+target_compile_options(${TIDAS_MPI_STATIC} PRIVATE "${mpi_comp_flags}")
+target_compile_options(${TIDAS_MPI_SHARED} PRIVATE "${mpi_comp_flags}")
 
 string(STRIP "${MPI_CXX_LINK_FLAGS}" mpi_link_flags)
-set_target_properties(tidas-mpi PROPERTIES LINK_FLAGS "${mpi_link_flags}")
+set_target_properties(${TIDAS_MPI_STATIC} PROPERTIES LINK_FLAGS "${mpi_link_flags}")
+set_target_properties(${TIDAS_MPI_SHARED} PROPERTIES LINK_FLAGS "${mpi_link_flags}")
 
-target_link_libraries(tidas-mpi tidas "${MPI_CXX_LIBRARIES}")
+target_link_libraries(${TIDAS_MPI_STATIC} ${TIDAS_STATIC} "${MPI_CXX_LIBRARIES}")
+target_link_libraries(${TIDAS_MPI_SHARED} ${TIDAS_SHARED} "${MPI_CXX_LIBRARIES}")
 
 install(DIRECTORY include/ DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
 
-# Hardcode this to "lib" for now, since lib32/lib64 is a pain
-# to use on many systems.
-#install(TARGETS tidas-mpi DESTINATION "${CMAKE_INSTALL_LIBDIR}")
-install(TARGETS tidas-mpi DESTINATION lib)
+install(TARGETS ${TIDAS_MPI_SHARED} DESTINATION "${CMAKE_INSTALL_LIBDIR}")

--- a/src/libtidas/CMakeLists.txt
+++ b/src/libtidas/CMakeLists.txt
@@ -1,7 +1,13 @@
 
-# Add the library target
+# Name of the internal static library
+set(TIDAS_STATIC tidas_)
 
-add_library(tidas
+# Name of the loadable module / shared library
+set(TIDAS_SHARED tidas)
+
+# Sources
+
+set(TIDAS_SOURCES
     src/sqlite3.c
     src/tidas_backend_getdata.cpp
     src/tidas_backend_hdf5.cpp
@@ -26,22 +32,30 @@ add_library(tidas
     src/tidas_volume.cpp
 )
 
+# Add the library targets
+
+add_library(${TIDAS_STATIC} STATIC ${TIDAS_SOURCES})
+add_library(${TIDAS_SHARED} SHARED ${TIDAS_SOURCES})
+
 if (HDF5_FOUND)
-    target_compile_definitions(tidas PRIVATE HAVE_HDF5=1)
-    target_include_directories(tidas PUBLIC ${HDF5_INCLUDE_DIRS})
+    target_compile_definitions(${TIDAS_STATIC} PRIVATE HAVE_HDF5=1)
+    target_compile_definitions(${TIDAS_SHARED} PRIVATE HAVE_HDF5=1)
+    target_include_directories(${TIDAS_STATIC} PUBLIC ${HDF5_INCLUDE_DIRS})
+    target_include_directories(${TIDAS_SHARED} PUBLIC ${HDF5_INCLUDE_DIRS})
+    target_link_libraries(${TIDAS_STATIC} ${HDF5_C_LIBRARIES})
+    target_link_libraries(${TIDAS_SHARED} ${HDF5_C_LIBRARIES})
 endif (HDF5_FOUND)
 
-target_include_directories(tidas PUBLIC
+target_include_directories(${TIDAS_STATIC} PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
     $<INSTALL_INTERFACE:include>
     PRIVATE src)
 
-target_link_libraries(tidas ${HDF5_C_LIBRARIES})
+target_include_directories(${TIDAS_SHARED} PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include>
+    PRIVATE src)
 
 install(DIRECTORY include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 
-# Hardcode this to "lib" for now, since lib32/lib64 is a pain
-# to use on many systems.
-#install(TARGETS tidas DESTINATION ${CMAKE_INSTALL_LIBDIR})
-install(TARGETS tidas DESTINATION lib)
-
+install(TARGETS ${TIDAS_SHARED} DESTINATION ${CMAKE_INSTALL_LIBDIR})

--- a/src/python/CMakeLists.txt
+++ b/src/python/CMakeLists.txt
@@ -1,4 +1,16 @@
 
+# Name of the serial internal static library
+set(TIDAS_STATIC tidas_)
+
+# Name of the serial loadable module / shared library
+set(TIDAS_SHARED tidas)
+
+# Name of the MPI internal static library
+set(TIDAS_MPI_STATIC tidas-mpi_)
+
+# Name of the MPI loadable module / shared library
+set(TIDAS_MPI_SHARED tidas-mpi)
+
 # pybind11 - this also finds the python interpreter
 
 add_subdirectory(pybind11)
@@ -23,7 +35,7 @@ set(PYTHON_SITE
 # Create a module for the serial tidas library
 
 pybind11_add_module(_pytidas MODULE pytidas.cpp)
-target_link_libraries(_pytidas PRIVATE tidas)
+target_link_libraries(_pytidas PRIVATE ${TIDAS_STATIC})
 
 # This is for the internal libtidas headers
 target_include_directories(_pytidas PRIVATE
@@ -45,7 +57,10 @@ install(FILES
 if(MPI_FOUND AND MPI4PY_FOUND)
     pybind11_add_module(_pytidas_mpi MODULE pytidas-mpi.cpp)
     target_compile_options(_pytidas_mpi PRIVATE "${MPI_CXX_COMPILE_FLAGS}")
-    target_link_libraries(_pytidas_mpi PRIVATE tidas-mpi "${MPI_CXX_LIBRARIES}")
+    target_link_libraries(_pytidas_mpi PRIVATE
+        ${TIDAS_MPI_STATIC}
+        "${MPI_CXX_LIBRARIES}"
+    )
     target_include_directories(_pytidas_mpi PRIVATE
         "${CMAKE_CURRENT_SOURCE_DIR}/../libtidas/src"
         "${CMAKE_CURRENT_SOURCE_DIR}/../libtidas-mpi/src"

--- a/src/tests-mpi/CMakeLists.txt
+++ b/src/tests-mpi/CMakeLists.txt
@@ -1,4 +1,7 @@
 
+# Name of the MPI internal static library
+set(TIDAS_MPI_STATIC tidas-mpi_)
+
 add_executable(tidas_test_mpi
     tidas_test_mpi.cpp
     tidas_mpi_test.cpp
@@ -26,7 +29,7 @@ set_target_properties(tidas_test_mpi
 )
 
 target_link_libraries(tidas_test_mpi
-    tidas-mpi gtest gtest_main "${MPI_CXX_LIBRARIES}"
+    ${TIDAS_MPI_STATIC} gtest gtest_main "${MPI_CXX_LIBRARIES}"
 )
 
 if (HDF5_FOUND)

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -1,8 +1,12 @@
 
+# Name of the serial internal static library
+set(TIDAS_STATIC tidas_)
+
 # Add internal googletest framework.  Must be added before the library
 # in order to define some variables.
 
-set(gtest_force_shared_crt TRUE)
+set(gtest_force_shared_crt ON CACHE BOOL "Always use shared." FORCE)
+
 add_subdirectory(gtest)
 include_directories("${gtest_SOURCE_DIR}/include")
 
@@ -26,7 +30,7 @@ target_include_directories(tidas_test PRIVATE
     "${CMAKE_CURRENT_SOURCE_DIR}/../libtidas/src"
 )
 
-target_link_libraries(tidas_test tidas gtest gtest_main)
+target_link_libraries(tidas_test ${TIDAS_STATIC} gtest gtest_main)
 
 if (HDF5_FOUND)
     target_compile_definitions(tidas_test PRIVATE HAVE_HDF5=1)

--- a/src/tests/gtest/googlemock/CMakeLists.txt
+++ b/src/tests/gtest/googlemock/CMakeLists.txt
@@ -108,10 +108,10 @@ endif()
 ########################################################################
 #
 # Install rules
-install(TARGETS gmock gmock_main
-  DESTINATION lib)
-install(DIRECTORY ${gmock_SOURCE_DIR}/include/gmock
-  DESTINATION include)
+# install(TARGETS gmock gmock_main
+#   DESTINATION lib)
+# install(DIRECTORY ${gmock_SOURCE_DIR}/include/gmock
+#   DESTINATION include)
 
 ########################################################################
 #

--- a/src/tests/gtest/googletest/CMakeLists.txt
+++ b/src/tests/gtest/googletest/CMakeLists.txt
@@ -102,10 +102,10 @@ endif()
 ########################################################################
 #
 # Install rules
-install(TARGETS gtest gtest_main
-  DESTINATION lib)
-install(DIRECTORY ${gtest_SOURCE_DIR}/include/gtest
-  DESTINATION include)
+# install(TARGETS gtest gtest_main
+#   DESTINATION lib)
+# install(DIRECTORY ${gtest_SOURCE_DIR}/include/gtest
+#   DESTINATION include)
 
 ########################################################################
 #


### PR DESCRIPTION
Static libraries are used internally by command line tests and the python package.  A Shared library is installed for compiled code to link against.